### PR TITLE
Enable use as CLI command (e.g. with pipx)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,33 @@ sm.match("I'm feeling {mood:smiley} *", "I'm feeling :) today!")
 >>> {"mood": "good"}
 ```
 
+## CLI Command
+
+You can also install `simplematch` for use as a CLI command e.g. using `pipx`.
+
+```sh
+pipx install simplematch
+```
+
+### Usage
+
+```sh
+# Usage
+simplematch [-h] [--regex] pattern string
+```
+
+For more detailed information on the arguments you can invoke
+`simplematch --help`.
+
+### Example
+
+Extract a date from a specific file name:
+
+```sh
+simplematch "Invoice_*_{year}_{month}_{day}.pdf" "Invoice_RE2321_2021_01_15.pdf"
+>>> {"year": "2021", "month": "01", "day": "15"}
+```
+
 ## Background
 
 `simplematch` aims to fill a gap between parsing with `str.split()` and regular

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.5"
 
+[tool.poetry.scripts]
+simplematch = "simplematch:simplematch_cli"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/simplematch.py
+++ b/simplematch.py
@@ -162,7 +162,7 @@ def to_regex(pattern):
     return Matcher(pattern).regex
 
 
-if __name__ == "__main__":
+def simplematch_cli():
     import json
     from argparse import ArgumentParser
 
@@ -177,3 +177,7 @@ if __name__ == "__main__":
     print(json.dumps(m.match(args.string)))
     if args.regex:
         print("Regex: " + m.regex)
+
+
+if __name__ == "__main__":
+    simplematch_cli()


### PR DESCRIPTION
Hello Thomas,

Earlier today I thought a command for `simplematch` would be really practical on the command line e.g. in combination with `jq`.
I found out `simplematch` was already supporting use as a CLI command (`python -m simplematch`).
For myself I already created a wrapper around `simplematch` which provides actual CLI commands installable with `pipx` (<https://gitlab.com/schorfma/simplematch-cli>).

I created this pull request to enable the use as a CLI command (e.g. installable with `pipx`).
Little changes and no additional dependencies are needed to make the existing functionality available as a command `simplematch` (See below).

Greetings
Martin

---

## Explanation of the intended Changes

* Move contents of `if __name__ == "__main__"` block into a function
* Invoke the created function in `if __name__ == "__main__"` block
* Declare the created function a script in section `[tool.poetry.scripts]` in `pyproject.toml`
* Point out the possibility to use `simplematch` as a CLI command within the `README.md`

By applying these changes `simplematch` could easily be installed as a CLI command using `pipx install simplematch` for example.